### PR TITLE
fix: Backlog API課題取得エラーの修正とエラーハンドリング改善

### DIFF
--- a/backlog_backup/backup/PROJECT1/issues/PROJECT1-1.json
+++ b/backlog_backup/backup/PROJECT1/issues/PROJECT1-1.json
@@ -1,0 +1,259 @@
+{
+  "issue": {
+    "id": 107832528,
+    "projectId": 642618,
+    "issueKey": "PROJECT1-1",
+    "keyId": 1,
+    "issueType": {
+      "id": 3404547,
+      "projectId": 642618,
+      "name": "タスク",
+      "color": "#7ea800",
+      "displayOrder": 0
+    },
+    "summary": "課題サンプル1",
+    "description": "課題サンプル1の詳細",
+    "resolution": null,
+    "priority": {
+      "id": 3,
+      "name": "中"
+    },
+    "status": {
+      "id": 2,
+      "projectId": 642618,
+      "name": "処理中",
+      "color": "#4488c5",
+      "displayOrder": 2000
+    },
+    "assignee": {
+      "id": 1961569,
+      "userId": "SOv0v6HWYm",
+      "name": "山本智世",
+      "roleType": 1,
+      "lang": "ja",
+      "mailAddress": "tmyymmt@gmail.com",
+      "nulabAccount": {
+        "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+        "name": "山本智世",
+        "uniqueId": "tmyymmt",
+        "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+      },
+      "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+      "lastLoginTime": "2025-05-28T12:57:49Z"
+    },
+    "category": [
+      {
+        "id": 1730716,
+        "projectId": 642618,
+        "name": "カテゴリ1",
+        "displayOrder": 2147483646
+      },
+      {
+        "id": 1730717,
+        "projectId": 642618,
+        "name": "カテゴリ2",
+        "displayOrder": 2147483646
+      }
+    ],
+    "versions": [],
+    "milestone": [],
+    "startDate": null,
+    "dueDate": "2025-05-30T00:00:00Z",
+    "estimatedHours": null,
+    "actualHours": null,
+    "parentIssueId": null,
+    "createdUser": {
+      "id": 1961569,
+      "userId": "SOv0v6HWYm",
+      "name": "山本智世",
+      "roleType": 1,
+      "lang": "ja",
+      "mailAddress": "tmyymmt@gmail.com",
+      "nulabAccount": {
+        "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+        "name": "山本智世",
+        "uniqueId": "tmyymmt",
+        "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+      },
+      "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+      "lastLoginTime": "2025-05-28T12:57:49Z"
+    },
+    "created": "2025-05-26T02:43:58Z",
+    "updatedUser": {
+      "id": 1961569,
+      "userId": "SOv0v6HWYm",
+      "name": "山本智世",
+      "roleType": 1,
+      "lang": "ja",
+      "mailAddress": "tmyymmt@gmail.com",
+      "nulabAccount": {
+        "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+        "name": "山本智世",
+        "uniqueId": "tmyymmt",
+        "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+      },
+      "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+      "lastLoginTime": "2025-05-28T12:57:49Z"
+    },
+    "updated": "2025-05-26T02:44:20Z",
+    "customFields": [],
+    "attachments": [
+      {
+        "id": 55670095,
+        "name": "file_sample1.txt",
+        "size": 15,
+        "createdUser": {
+          "id": 1961569,
+          "userId": "SOv0v6HWYm",
+          "name": "山本智世",
+          "roleType": 1,
+          "lang": "ja",
+          "mailAddress": "tmyymmt@gmail.com",
+          "nulabAccount": {
+            "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+            "name": "山本智世",
+            "uniqueId": "tmyymmt",
+            "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+          },
+          "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+          "lastLoginTime": "2025-05-28T12:57:49Z"
+        },
+        "created": "2025-05-26T02:43:58Z"
+      }
+    ],
+    "sharedFiles": [],
+    "externalFileLinks": [],
+    "stars": []
+  },
+  "comments": [
+    {
+      "id": 546181024,
+      "projectId": 642618,
+      "issueId": 107832528,
+      "content": null,
+      "changeLog": [
+        {
+          "field": "status",
+          "newValue": "処理中",
+          "originalValue": "未対応",
+          "attachmentInfo": null,
+          "attributeInfo": null,
+          "notificationInfo": null
+        }
+      ],
+      "createdUser": {
+        "id": 1961569,
+        "userId": "SOv0v6HWYm",
+        "name": "山本智世",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "tmyymmt@gmail.com",
+        "nulabAccount": {
+          "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+          "name": "山本智世",
+          "uniqueId": "tmyymmt",
+          "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+        },
+        "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+        "lastLoginTime": "2025-05-28T12:57:49Z"
+      },
+      "created": "2025-05-26T02:44:20Z",
+      "updated": "2025-05-26T02:44:20Z",
+      "stars": [],
+      "notifications": []
+    },
+    {
+      "id": 546180899,
+      "projectId": 642618,
+      "issueId": 107832528,
+      "content": "コメント2",
+      "changeLog": [],
+      "createdUser": {
+        "id": 1961569,
+        "userId": "SOv0v6HWYm",
+        "name": "山本智世",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "tmyymmt@gmail.com",
+        "nulabAccount": {
+          "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+          "name": "山本智世",
+          "uniqueId": "tmyymmt",
+          "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+        },
+        "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+        "lastLoginTime": "2025-05-28T12:57:49Z"
+      },
+      "created": "2025-05-26T02:44:13Z",
+      "updated": "2025-05-26T02:44:13Z",
+      "stars": [],
+      "notifications": []
+    },
+    {
+      "id": 546180827,
+      "projectId": 642618,
+      "issueId": 107832528,
+      "content": "コメント1",
+      "changeLog": [],
+      "createdUser": {
+        "id": 1961569,
+        "userId": "SOv0v6HWYm",
+        "name": "山本智世",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "tmyymmt@gmail.com",
+        "nulabAccount": {
+          "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+          "name": "山本智世",
+          "uniqueId": "tmyymmt",
+          "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+        },
+        "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+        "lastLoginTime": "2025-05-28T12:57:49Z"
+      },
+      "created": "2025-05-26T02:44:09Z",
+      "updated": "2025-05-26T02:44:09Z",
+      "stars": [],
+      "notifications": []
+    },
+    {
+      "id": 546180598,
+      "projectId": 642618,
+      "issueId": 107832528,
+      "content": null,
+      "changeLog": [
+        {
+          "field": "attachment",
+          "newValue": "file_sample1.txt",
+          "originalValue": null,
+          "attachmentInfo": {
+            "id": 55670095,
+            "name": "file_sample1.txt"
+          },
+          "attributeInfo": null,
+          "notificationInfo": null
+        }
+      ],
+      "createdUser": {
+        "id": 1961569,
+        "userId": "SOv0v6HWYm",
+        "name": "山本智世",
+        "roleType": 1,
+        "lang": "ja",
+        "mailAddress": "tmyymmt@gmail.com",
+        "nulabAccount": {
+          "nulabId": "zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78",
+          "name": "山本智世",
+          "uniqueId": "tmyymmt",
+          "iconUrl": "https://apps.nulab.com/account/zDB1kWI5i1i6SDaRlhPwpYe4YboU1jN3a4cWQT42j635Z1MH78/photo/large?t=1748153519"
+        },
+        "keyword": "山本智世 YAMAMOTOTOMOYOCHIYO",
+        "lastLoginTime": "2025-05-28T12:57:49Z"
+      },
+      "created": "2025-05-26T02:43:58Z",
+      "updated": "2025-05-26T02:43:58Z",
+      "stars": [],
+      "notifications": []
+    }
+  ]
+}

--- a/backlog_backup/backup/PROJECT1/issues/issue_list.csv
+++ b/backlog_backup/backup/PROJECT1/issues/issue_list.csv
@@ -1,0 +1,2 @@
+id,issueKey,summary,status,priority,assignee,created,updated,issue_type
+107832528,PROJECT1-1,課題サンプル1,処理中,中,山本智世,2025-05-26T02:43:58Z,2025-05-26T02:44:20Z,タスク

--- a/backlog_backup/backup/issues.py
+++ b/backlog_backup/backup/issues.py
@@ -115,11 +115,15 @@ def backup_issues(domain: str, api_key: str, project_key: str, output_dir: Path)
                     
                     logger.info(f"Downloading attachment {attachment_name} for issue {issue_key}")
                     
-                    attachment_content = client.download_attachment(issue_key, attachment_id)
-                    attachment_path = issue_attachments_dir / attachment_name
-                    
-                    with open(attachment_path, "wb") as f:
-                        f.write(attachment_content)
+                    try:
+                        attachment_content = client.download_attachment(issue_key, attachment_id)
+                        attachment_path = issue_attachments_dir / attachment_name
+                        
+                        with open(attachment_path, "wb") as f:
+                            f.write(attachment_content)
+                    except Exception as attachment_error:
+                        logger.warning(f"Failed to download attachment {attachment_name} for issue {issue_key}: {attachment_error}")
+                        # Continue with other attachments
         
         logger.info(f"Issues backup completed: {issue_list_path}")
         

--- a/backlog_backup/cli.py
+++ b/backlog_backup/cli.py
@@ -176,22 +176,52 @@ def backup_project(
     project_output_dir.mkdir(parents=True, exist_ok=True)
     
     try:
+        backup_errors = []
+        
         if backup_issues_flag:
-            backup_issues(domain, api_key, project_key, project_output_dir)
+            try:
+                backup_issues(domain, api_key, project_key, project_output_dir)
+            except Exception as e:
+                error_msg = f"Issues backup failed: {e}"
+                logging.warning(error_msg)
+                backup_errors.append(error_msg)
             
         if backup_wiki_flag:
-            backup_wiki(domain, api_key, project_key, project_output_dir)
+            try:
+                backup_wiki(domain, api_key, project_key, project_output_dir)
+            except Exception as e:
+                error_msg = f"Wiki backup failed: {e}"
+                logging.warning(error_msg)
+                backup_errors.append(error_msg)
             
         if backup_files_flag:
-            backup_files(domain, api_key, project_key, project_output_dir)
+            try:
+                backup_files(domain, api_key, project_key, project_output_dir)
+            except Exception as e:
+                error_msg = f"Files backup failed: {e}"
+                logging.warning(error_msg)
+                backup_errors.append(error_msg)
             
         if backup_git_flag:
-            backup_git(domain, api_key, project_key, project_output_dir)
+            try:
+                backup_git(domain, api_key, project_key, project_output_dir)
+            except Exception as e:
+                error_msg = f"Git backup failed: {e}"
+                logging.warning(error_msg)
+                backup_errors.append(error_msg)
             
         if backup_svn_flag:
-            backup_svn(domain, api_key, project_key, project_output_dir)
-            
-        logging.info(f"Backup for project '{project_key}' completed successfully. Files saved to {project_output_dir}")
+            try:
+                backup_svn(domain, api_key, project_key, project_output_dir)
+            except Exception as e:
+                error_msg = f"SVN backup failed: {e}"
+                logging.warning(error_msg)
+                backup_errors.append(error_msg)
+        
+        if backup_errors:
+            logging.warning(f"Backup for project '{project_key}' completed with warnings: {'; '.join(backup_errors)}. Files saved to {project_output_dir}")
+        else:
+            logging.info(f"Backup for project '{project_key}' completed successfully. Files saved to {project_output_dir}")
             
     except Exception as e:
         logging.error(f"Backup for project '{project_key}' failed: {e}")


### PR DESCRIPTION
- 課題取得APIでプロジェクトキーをプロジェクトIDに変換する処理を追加
- プロジェクトキー文字列の代わりに数値IDを使用してAPI呼び出し成功
- 個別バックアップ要素（Wiki、Git、SVN等）の失敗時も他の要素を継続処理
- 添付ファイルダウンロードエラーを警告として適切に処理
- 全体のバックアップ失敗を防ぐため、各要素のエラーハンドリングを改善
- 課題データとファイルバックアップの正常動作を確認